### PR TITLE
Replace 'user_uploaded_content' links with 'loginportal123' links

### DIFF
--- a/ispyfj/ispyfj.py
+++ b/ispyfj/ispyfj.py
@@ -175,6 +175,8 @@ class IspyFJ(commands.Cog):
                 break
             else:
                 raise VideoNotFoundError("Failed to extract video URL after multiple attempts.")
+            # If the video url has 'user_uploaded_content', replace that with 'loginportal123' - this fixes an issue with discord embedding
+            video_url = video_url.replace('user_uploaded_content', 'loginportal123')
             # Cache the result
             self.cache[link] = (current_time, video_url)
             return video_url

--- a/ispyfj/test_ispyfj.py
+++ b/ispyfj/test_ispyfj.py
@@ -198,13 +198,13 @@ def funnyjunk_credentials():
         (
             "Crose Rid",
             "https://funnyjunk.com/Crose+rid/wrrcTje/",
-            "https://user_uploaded_content.funnyjunk.com/movies/Crose+rid_5be80c_12352736.mp4",
+            "https://loginportal123.funnyjunk.com/movies/Crose+rid_5be80c_12352736.mp4",
         ),
         # TODO: Add more real URLs to test the various extraction methods
         (  # normal video URL
             "How dreaming feels like",
             "https://funnyjunk.com/How+dreaming+feels+like/vttzRig/",
-            "https://user_uploaded_content.funnyjunk.com/hdgifs/How+dreaming+feels+like_247d10_11748871.mp4",
+            "https://loginportal123.funnyjunk.com/hdgifs/How+dreaming+feels+like_247d10_11748871.mp4",
         ),
         (  # spaces in the video URL are replaced with '+'
             "Unkempt luckless rapidfire",


### PR DESCRIPTION
This fixes an issue with the discord embeds (and video downloading?) not working with these types of links.